### PR TITLE
Change from address to `noreply`

### DIFF
--- a/lib/email_message.js
+++ b/lib/email_message.js
@@ -24,7 +24,7 @@ class EmailMessage {
   messageBody() {
     return {
       to: this.emailAddress,
-      from: "stuart@dxw.com",
+      from: "noreply@dxw.com",
       subject: "Your upcoming rotation",
       text: this.message,
     };

--- a/spec/email_message.test.js
+++ b/spec/email_message.test.js
@@ -10,7 +10,7 @@ describe("EmailMessage", () => {
 
     expect(sgMail.send).toHaveBeenCalledWith({
       to: "foo@example.com",
-      from: "stuart@dxw.com",
+      from: "noreply@dxw.com",
       subject: "Your upcoming rotation",
       text: "Details of your upcoming rotation",
     });


### PR DESCRIPTION
We had the from address temporarily set to my address. Now the domain has been verified as working, and we can send email, it makes sense to have a more generic email. Tested and confirmed working.