### PR TITLE
Rota alerts for in hours support

### DIFF
--- a/lib/rota_alerts.js
+++ b/lib/rota_alerts.js
@@ -12,8 +12,8 @@ class RotaAlerts {
     const rotation = await this.upcoming(this.type);
 
     if (rotation) {
-      await this.sendMessage(rotation.first_line.email, rotation.start_date);
-      await this.sendMessage(rotation.second_line.email, rotation.start_date);
+      await this.sendMessage(rotation.members[0], rotation.start_date);
+      await this.sendMessage(rotation.members[1], rotation.start_date);
     }
   }
 
@@ -22,22 +22,21 @@ class RotaAlerts {
     return await rotationFinder.find();
   }
 
-  async sendMessage(email, startDate) {
+  async sendMessage(membership, startDate) {
     const date = moment(startDate).format("dddd Do MMMM");
-    const text = this.message(date);
-    const slackMessage = new SlackMessage(email, text);
-    const emailMessage = new EmailMessage(email, text);
+    const text = this.message(membership, date);
+    const slackMessage = new SlackMessage(membership.email, text);
+    const emailMessage = new EmailMessage(membership.email, text);
 
     await Promise.all([slackMessage.send(), emailMessage.send()]);
   }
 
-  message(date) {
-    let typeDescription = {
-      ooh: "out of hours",
-      support: "support",
-    }[this.type];
-
-    return `You have an upcoming ${typeDescription} allocation on ${date}. Can't do it? Ask in #dxw-tech-team and see if someone wants to swap`;
+  message(membership, date) {
+    return (
+      `You have an upcoming **${membership.rota}** allocation on ${date}. ` +
+      `Your role is **${membership.role}**. ` +
+      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+    );
   }
 
   static async runner() {

--- a/lib/upcoming_rotation.js
+++ b/lib/upcoming_rotation.js
@@ -3,6 +3,7 @@ const moment = require("moment");
 
 class UpcomingRotation {
   constructor(type) {
+    this.type = type;
     this.date = moment().add(1, "week").format("YYYY-MM-DD");
     this.url = {
       ooh: "https://dxw-support-rota.herokuapp.com/out-of-hours/rota.json",
@@ -16,10 +17,67 @@ class UpcomingRotation {
 
   async find() {
     const response = await axios.get(this.url);
-
-    return response.data.find((rotation) => {
+    const inconsistentRotation = response.data.find((rotation) => {
       return rotation.start_date === this.date;
     });
+    return this.consistentRotation(inconsistentRotation);
+  }
+
+  consistentRotation(rotation) {
+    if (rotation) {
+      return {
+        start_date: rotation.start_date,
+        end_date: rotation.end_date,
+        members: this.members(rotation),
+      };
+    }
+  }
+
+  members(rotation) {
+    console.log(this.type);
+    switch (this.type) {
+      case "ooh":
+        return this.outOfHoursMembers(rotation);
+      case "support":
+        return this.inHoursMembers(rotation);
+      default:
+        throw new Error(`The rotation type ${this.type} is unknown.`);
+    }
+  }
+
+  outOfHoursMembers(rotation) {
+    return [
+      {
+        rota: "out-of-hours",
+        role: "first line",
+        name: rotation.first_line.name,
+        email: rotation.first_line.email,
+      },
+      {
+        rota: "out-of-hours",
+        role: "second line",
+        name: rotation.second_line.name,
+        email: rotation.second_line.email,
+      },
+    ];
+  }
+
+  inHoursMembers(rotation) {
+    console.log(rotation);
+    return [
+      {
+        rota: "in-hours",
+        role: "developer",
+        name: rotation.developer.name,
+        email: rotation.developer.email,
+      },
+      {
+        rota: "in-hours",
+        role: "ops",
+        name: rotation.ops.name,
+        email: rotation.ops.email,
+      },
+    ];
   }
 }
 

--- a/spec/rota_alerts.test.js
+++ b/spec/rota_alerts.test.js
@@ -14,7 +14,7 @@ describe("RotaAlerts", () => {
     EmailMessage.mockClear();
   });
 
-  test("sends notifications when a rotation is available", async () => {
+  test("sends notifications when a out of hours rotation is available", async () => {
     UpcomingRotation.mockImplementationOnce(() => {
       return {
         find: () => {
@@ -41,19 +41,27 @@ describe("RotaAlerts", () => {
     expect(EmailMessage).toHaveBeenCalledTimes(2);
     expect(SlackMessage).toHaveBeenCalledWith(
       "eve@example.com",
-      "You have an upcoming out of hours allocation on Thursday 9th January. Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
+      "Your role is **first line**." +
+      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
     );
     expect(SlackMessage).toHaveBeenCalledWith(
       "trent@example.com",
-      "You have an upcoming out of hours allocation on Thursday 9th January. Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
+      "Your role is **second line**." +
+      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
     );
     expect(EmailMessage).toHaveBeenCalledWith(
       "eve@example.com",
-      "You have an upcoming out of hours allocation on Thursday 9th January. Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
+      "Your role is **first line**." +
+      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
     );
     expect(EmailMessage).toHaveBeenCalledWith(
       "trent@example.com",
-      "You have an upcoming out of hours allocation on Thursday 9th January. Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
+      "Your role is **second line**." +
+      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
     );
   });
 

--- a/spec/rota_alerts.test.js
+++ b/spec/rota_alerts.test.js
@@ -14,55 +14,122 @@ describe("RotaAlerts", () => {
     EmailMessage.mockClear();
   });
 
-  test("sends notifications when a out of hours rotation is available", async () => {
-    UpcomingRotation.mockImplementationOnce(() => {
-      return {
-        find: () => {
-          return Promise.resolve({
-            start_date: "2020-01-09",
-            end_date: "2020-01-16",
-            first_line: {
-              name: "Eve",
-              email: "eve@example.com",
-            },
-            second_line: {
-              name: "Trent",
-              email: "trent@example.com",
-            },
-          });
-        },
-      };
+  describe("when the rotation has the OOH (first_line/second_line) shape", () => {
+    test("sends notifications when a out of hours rotation is available", async () => {
+      UpcomingRotation.mockImplementationOnce(() => {
+        return {
+          find: () => {
+            return Promise.resolve({
+              start_date: "2020-01-09",
+              end_date: "2020-01-16",
+              members: [
+                {
+                  role: "first line",
+                  rota: "out-of-hours",
+                  name: "Eve",
+                  email: "eve@example.com",
+                },
+                {
+                  role: "second line",
+                  rota: "out-of-hours",
+                  name: "Trent",
+                  email: "trent@example.com",
+                },
+              ],
+            });
+          },
+        };
+      });
+
+      const rotaAlerts = new RotaAlerts("ooh");
+      await rotaAlerts.run();
+
+      expect(SlackMessage).toHaveBeenCalledTimes(2);
+      expect(EmailMessage).toHaveBeenCalledTimes(2);
+      expect(SlackMessage).toHaveBeenCalledWith(
+        "eve@example.com",
+        "You have an upcoming **out-of-hours** allocation on Thursday 9th January. " +
+          "Your role is **first line**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(SlackMessage).toHaveBeenCalledWith(
+        "trent@example.com",
+        "You have an upcoming **out-of-hours** allocation on Thursday 9th January. " +
+          "Your role is **second line**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(EmailMessage).toHaveBeenCalledWith(
+        "eve@example.com",
+        "You have an upcoming **out-of-hours** allocation on Thursday 9th January. " +
+          "Your role is **first line**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(EmailMessage).toHaveBeenCalledWith(
+        "trent@example.com",
+        "You have an upcoming **out-of-hours** allocation on Thursday 9th January. " +
+          "Your role is **second line**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
     });
+  });
 
-    const rotaAlerts = new RotaAlerts("ooh");
-    await rotaAlerts.run();
+  describe("when the rotation has the Support (developer/ops) shape", () => {
+    test("sends notifications when a out of hours rotation is available", async () => {
+      UpcomingRotation.mockImplementationOnce(() => {
+        return {
+          find: () => {
+            return Promise.resolve({
+              start_date: "2020-01-09",
+              end_date: "2020-01-16",
+              members: [
+                {
+                  role: "developer",
+                  rota: "in-hours",
+                  name: "Sandy",
+                  email: "sandy@example.com",
+                },
+                {
+                  role: "ops",
+                  rota: "in-hours",
+                  name: "Frances",
+                  email: "frances@example.com",
+                },
+              ],
+            });
+          },
+        };
+      });
 
-    expect(SlackMessage).toHaveBeenCalledTimes(2);
-    expect(EmailMessage).toHaveBeenCalledTimes(2);
-    expect(SlackMessage).toHaveBeenCalledWith(
-      "eve@example.com",
-      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
-      "Your role is **first line**." +
-      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
-    );
-    expect(SlackMessage).toHaveBeenCalledWith(
-      "trent@example.com",
-      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
-      "Your role is **second line**." +
-      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
-    );
-    expect(EmailMessage).toHaveBeenCalledWith(
-      "eve@example.com",
-      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
-      "Your role is **first line**." +
-      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
-    );
-    expect(EmailMessage).toHaveBeenCalledWith(
-      "trent@example.com",
-      "You have an upcoming **out of hours** allocation on Thursday 9th January. " +
-      "Your role is **second line**." +
-      "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
-    );
+      const rotaAlerts = new RotaAlerts("support");
+      await rotaAlerts.run();
+
+      expect(SlackMessage).toHaveBeenCalledTimes(2);
+      expect(EmailMessage).toHaveBeenCalledTimes(2);
+      expect(SlackMessage).toHaveBeenCalledWith(
+        "sandy@example.com",
+        "You have an upcoming **in-hours** allocation on Thursday 9th January. " +
+          "Your role is **developer**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(SlackMessage).toHaveBeenCalledWith(
+        "frances@example.com",
+        "You have an upcoming **in-hours** allocation on Thursday 9th January. " +
+          "Your role is **ops**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(EmailMessage).toHaveBeenCalledWith(
+        "sandy@example.com",
+        "You have an upcoming **in-hours** allocation on Thursday 9th January. " +
+          "Your role is **developer**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+      expect(EmailMessage).toHaveBeenCalledWith(
+        "frances@example.com",
+        "You have an upcoming **in-hours** allocation on Thursday 9th January. " +
+          "Your role is **ops**. " +
+          "Can't do it? Ask in #dxw-tech-team and see if someone wants to swap"
+      );
+    });
   });
 
   test("does not send Slack notifications when there is no rotation", async () => {

--- a/spec/upcoming_rotation.test.js
+++ b/spec/upcoming_rotation.test.js
@@ -5,74 +5,131 @@ const axios = require("axios");
 jest.mock("axios");
 
 describe("UpcomingRotations", () => {
-  beforeEach(() => {
-    // Mock the HTTP reponse from the API
-    const data = {
-      data: [
-        {
-          start_date: "2020-01-01",
-          end_date: "2020-01-08",
-          first_line: {
-            name: "Alice",
-            email: "alice@example.com",
+  describe("when rotation has the 'ooh' shape (first_line/second_line)", () => {
+    beforeEach(() => {
+      // Mock the HTTP reponse from the API
+      const oohData = {
+        data: [
+          {
+            start_date: "2020-01-01",
+            end_date: "2020-01-08",
+            first_line: {
+              name: "Alice",
+              email: "alice@example.com",
+            },
+            second_line: {
+              name: "Bob",
+              email: "bob@example.com",
+            },
           },
-          second_line: {
-            name: "Bob",
-            email: "bob@example.com",
+          {
+            start_date: "2020-01-09",
+            end_date: "2020-01-16",
+            first_line: {
+              name: "Eve",
+              email: "eve@example.com",
+            },
+            second_line: {
+              name: "Trent",
+              email: "trent@example.com",
+            },
           },
-        },
-        {
-          start_date: "2020-01-09",
-          end_date: "2020-01-16",
-          first_line: {
+        ],
+      };
+
+      axios.get.mockImplementationOnce(() => Promise.resolve(oohData));
+    });
+
+    test("returns a consistently shaped entity when one is available", async () => {
+      MockDate.set("2020-01-02");
+
+      const upcomingRotation = new UpcomingRotation("ooh");
+
+      expect(await upcomingRotation.find()).toEqual({
+        start_date: "2020-01-09",
+        end_date: "2020-01-16",
+        members: [
+          {
+            rota: "out-of-hours",
+            role: "first line",
             name: "Eve",
             email: "eve@example.com",
           },
-          second_line: {
+          {
+            rota: "out-of-hours",
+            role: "second line",
             name: "Trent",
             email: "trent@example.com",
           },
-        },
-      ],
-    };
+        ],
+      });
+    });
 
-    axios.get.mockImplementationOnce(() => Promise.resolve(data));
+    test("returns nothing when there is no rotation", async () => {
+      MockDate.set("2020-01-03");
+
+      const upcomingRotation = new UpcomingRotation("ooh");
+
+      expect(await upcomingRotation.find()).toEqual(undefined);
+    });
+
+    test("raises an error if the rotation type does not exist", () => {
+      expect(() => {
+        new UpcomingRotation("foo");
+      }).toThrow("Rotation type foo does not exist");
+    });
+  });
+
+  describe("when rotation has the 'support' shape (developer/ops)", () => {
+    beforeEach(() => {
+      // Mock the HTTP reponse from the API
+      const supportData = {
+        data: [
+          {
+            start_date: "2020-01-09",
+            end_date: "2020-01-16",
+            developer: {
+              name: "Sandy",
+              email: "Sandy@example.com",
+            },
+            ops: {
+              name: "Frances",
+              email: "Frances@example.com",
+            },
+          },
+        ],
+      };
+
+      axios.get.mockImplementationOnce(() => Promise.resolve(supportData));
+    });
+
+    test("returns a consistently shaped entity when one is available", async () => {
+      MockDate.set("2020-01-02");
+
+      const upcomingRotation = new UpcomingRotation("support");
+
+      expect(await upcomingRotation.find()).toEqual({
+        start_date: "2020-01-09",
+        end_date: "2020-01-16",
+        members: [
+          {
+            rota: "in-hours",
+            role: "developer",
+            name: "Sandy",
+            email: "Sandy@example.com",
+          },
+          {
+            rota: "in-hours",
+            role: "ops",
+            name: "Frances",
+            email: "Frances@example.com",
+          },
+        ],
+      });
+    });
   });
 
   afterEach(() => {
     MockDate.reset();
-  });
-
-  test("returns a rotation when one is available", async () => {
-    MockDate.set("2020-01-02");
-
-    const upcomingRotation = new UpcomingRotation("ooh");
-
-    expect(await upcomingRotation.find()).toEqual({
-      start_date: "2020-01-09",
-      end_date: "2020-01-16",
-      first_line: {
-        name: "Eve",
-        email: "eve@example.com",
-      },
-      second_line: {
-        name: "Trent",
-        email: "trent@example.com",
-      },
-    });
-  });
-
-  test("returns nothing when there is no rotation", async () => {
-    MockDate.set("2020-01-03");
-
-    const upcomingRotation = new UpcomingRotation("ooh");
-
-    expect(await upcomingRotation.find()).toEqual(undefined);
-  });
-
-  test("raises an error if the rotation type does not exist", () => {
-    expect(() => {
-      new UpcomingRotation("foo");
-    }).toThrow("Rotation type foo does not exist");
   });
 });


### PR DESCRIPTION
Our dxw-support-rota.herokuapp.com middleware which
provides support information from Opsgenie represents
support periods in two differnt ways, according to the
lables given to the team members' roles.

The 'Support' rotation element has a different shape to the
'OOH'rotation:

'support' rotation shape:

from`https://dxw-support-rota.herokuapp.com/support/rota.json`

```
  {
    start_date: '2020-01-09',
    end_date: '2020-01-16',
    developer: { name: 'Sandy', email: 'sandy@example.com' },
    ops: { name: 'Frances', email: 'frances@example.com' }
  }
```

'ooh' rotation shape:

from `https://dxw-support-rota.herokuapp.com/out-of-hours/rota.json`

```
  {
    start_date: '2020-01-09',
    end_date: '2020-01-16',
    first_line: { name: 'Eve', email: 'eve@example.com' },
    second_line: { name: 'Trent', email: 'trent@example.com' }
  }
```

At present the `RotaAlerts.run()` function expects both types of rota representation to have `first_line` and `second_line` properties, and so blows up when it encounters the in-hours "Support" type.